### PR TITLE
Fix package scan of MongoDB importer.

### DIFF
--- a/location-importer-mongo/src/main/java/com/location/importer/MongoDBDataImporterApplication.java
+++ b/location-importer-mongo/src/main/java/com/location/importer/MongoDBDataImporterApplication.java
@@ -7,12 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 /**
  * This class initializes the command line application that is based on Spring Boot for data import.
  */
-@SpringBootApplication(
-    scanBasePackages = {
-      "com.location.finder.mongo",
-      "com.location.importer",
-      "com.location.finder.application"
-    })
+@SpringBootApplication(scanBasePackages = {"com.location.finder.mongo", "com.location.importer"})
 public class MongoDBDataImporterApplication implements CommandLineRunner {
 
   /** The data import service for reading food truck csv and inserting into MongoDB. */


### PR DESCRIPTION
MongoDBDataImporterApplication unnecessarily scans for com.location.finder.application which belongs to application package.